### PR TITLE
enable debug logging

### DIFF
--- a/src/main/scala/com/vast/sbtlogger/SbtLogger.scala
+++ b/src/main/scala/com/vast/sbtlogger/SbtLogger.scala
@@ -29,8 +29,8 @@ class SbtLogger(sbtLogger: sbt.Logger) extends MarkerIgnoringBase with Logger {
   override def isErrorEnabled: Boolean = true
   override def isWarnEnabled: Boolean = true
   override def isInfoEnabled: Boolean = true
-  override def isDebugEnabled: Boolean = false
-  override def isTraceEnabled: Boolean = false
+  override def isDebugEnabled: Boolean = true
+  override def isTraceEnabled: Boolean = true
 
   override def warn(msg: String): Unit = writeLogMessage(WARN, Some(msg))
   override def warn(format: String, arg: scala.Any): Unit = formatAndLog(WARN, format, arg)


### PR DESCRIPTION
As far as I can tell, the fact that it is disabled in the `Logger` means that even if I increase SBT's log level, debug and trace messages never make it through to SBT.

I agree that this should be in some way configurable, but for now, it's probably best to enable it. I don't think this is going to be a performance issue.
